### PR TITLE
fixed default parameter for adapter sequences

### DIFF
--- a/cwl/picard_alignmentsummary_metrics.cwl
+++ b/cwl/picard_alignmentsummary_metrics.cwl
@@ -60,7 +60,7 @@ inputs:
     prefix: IS_BISULFITE_SEQUENCED=
     separate: false
   type: string
-- default: ''
+- default: null
   id: adapter_sequence
   inputBinding:
     position: 7

--- a/tests/test-descriptions.yaml
+++ b/tests/test-descriptions.yaml
@@ -32,7 +32,7 @@
     alignmentsummarymetrics_txt:
       basename: output_alignment_metrics.txt
       class: File
-      size: 1909
+      size: 1879
   tool: ../cwl/picard_alignmentsummary_metrics.cwl
   doc: Test that we can calculate picard alignment summary metrics
   short_name: alignment metrics


### PR DESCRIPTION
Using an empty string as the default argument in picard_alignmentsummary_metrics.cwl does not behave properly and was causing adjacent arguments to not be passed in to the appropriate fields. Thus, I've changed the default value for adapter_sequence to null. 